### PR TITLE
feat: Pin improvements and stability fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "convex": "^1.31.5",
+        "lucide-react": "^0.562.0",
         "maplibre-gl": "^5.16.0",
         "next": "16.1.3",
         "pmtiles": "^4.3.2",
@@ -6550,6 +6551,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.562.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.562.0.tgz",
+      "integrity": "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "convex": "^1.31.5",
+    "lucide-react": "^0.562.0",
     "maplibre-gl": "^5.16.0",
     "next": "16.1.3",
     "pmtiles": "^4.3.2",

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -220,6 +220,7 @@ function PinWithPhoto({
       isCompleted={!!poi.completion}
       photoUrl={photoUrl ?? undefined}
       onClick={handleClick}
+      order={poi.order}
     />
   );
 }

--- a/src/components/MapLibre/MapContainer.tsx
+++ b/src/components/MapLibre/MapContainer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useMemo } from "react";
 import maplibregl from "maplibre-gl";
 import { Protocol } from "pmtiles";
 import type { Bounds } from "@/../lib/types";
@@ -42,6 +42,7 @@ export function Map({ bounds, children }: MapProps) {
     // Initialize map with Protomaps vector tiles + Level 2 simplified style
     const map = new maplibregl.Map({
       container: containerRef.current,
+      attributionControl: false,
       style: {
         version: 8,
         glyphs: "https://cdn.protomaps.com/fonts/pbf/{fontstack}/{range}.pbf",
@@ -169,10 +170,17 @@ export function Map({ bounds, children }: MapProps) {
     }
   }, [bounds, mapReady]);
 
+  // Memoize context value to prevent unnecessary re-renders of children
+  const contextValue = useMemo(
+    () => ({ map: mapRef.current }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [mapReady] // Only update when map becomes ready
+  );
+
   return (
     <div ref={containerRef} className="w-full h-full">
       {mapReady && (
-        <MapContext.Provider value={{ map: mapRef.current }}>
+        <MapContext.Provider value={contextValue}>
           {children}
         </MapContext.Provider>
       )}

--- a/src/components/MapLibre/Pin.tsx
+++ b/src/components/MapLibre/Pin.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useCallback } from "react";
+import { useEffect, useRef, memo } from "react";
 import maplibregl from "maplibre-gl";
 import { useMapLibre } from "./MapContext";
 
@@ -10,11 +10,13 @@ interface PinProps {
   isCompleted: boolean;
   photoUrl?: string;
   onClick: () => void;
+  // Order number to display for uncompleted POIs
+  order?: number;
   // Multiplayer: team colors for completed POIs
   teamColors?: string[];
 }
 
-export function Pin({ lat, lng, isCompleted, photoUrl, onClick, teamColors }: PinProps) {
+export const Pin = memo(function Pin({ lat, lng, isCompleted, photoUrl, onClick, order, teamColors }: PinProps) {
   const map = useMapLibre();
   const markerRef = useRef<maplibregl.Marker | null>(null);
   const elementRef = useRef<HTMLDivElement | null>(null);
@@ -25,12 +27,48 @@ export function Pin({ lat, lng, isCompleted, photoUrl, onClick, teamColors }: Pi
     onClickRef.current = onClick;
   }, [onClick]);
 
+  // Helper to generate marker HTML content
+  const getMarkerContent = (completed: boolean, photo?: string, colors?: string[], orderNum?: number) => {
+    if (completed && photo) {
+      const primaryTeamColor = colors && colors.length > 0 ? colors[0] : "#22c55e";
+      let ringsHtml = "";
+      if (colors && colors.length > 1) {
+        const ringSize = 4;
+        colors.forEach((color, i) => {
+          const offset = i * ringSize;
+          ringsHtml += `<div class="absolute inset-0 rounded-full" style="border: 3px solid ${color}; margin: -${offset}px;"></div>`;
+        });
+      }
+      return `
+        <div class="relative w-16 h-16 rounded-full shadow-lg overflow-visible cursor-pointer transform -translate-y-1 hover:scale-110 transition-transform">
+          ${ringsHtml}
+          <div class="w-full h-full rounded-full border-4 overflow-hidden" style="border-color: ${primaryTeamColor};">
+            <img src="${photo}" class="w-full h-full object-cover" alt="completed" />
+          </div>
+        </div>
+      `;
+    }
+    const displayText = orderNum !== undefined ? orderNum : "?";
+    return `
+      <div class="w-12 h-12 bg-gray-400 rounded-full border-4 border-white shadow-lg flex items-center justify-center cursor-pointer transform -translate-y-1 hover:scale-110 transition-transform">
+        <span class="text-white text-xl font-bold">${displayText}</span>
+      </div>
+    `;
+  };
+
   useEffect(() => {
     if (!map) return;
 
-    // Create marker element
+    // Guard against duplicate markers (React Strict Mode)
+    if (markerRef.current) {
+      markerRef.current.remove();
+      markerRef.current = null;
+    }
+
+    // Create marker element with initial content
     const el = document.createElement("div");
     el.className = "maplibre-pin";
+    el.innerHTML = getMarkerContent(isCompleted, photoUrl, teamColors, order);
     elementRef.current = el;
 
     // Create marker
@@ -58,38 +96,8 @@ export function Pin({ lat, lng, isCompleted, photoUrl, onClick, teamColors }: Pi
   // Update marker content when completion status changes
   useEffect(() => {
     if (!elementRef.current) return;
-
-    if (isCompleted && photoUrl) {
-      // Primary team color for the inner photo border (first team to complete)
-      const primaryTeamColor = teamColors && teamColors.length > 0 ? teamColors[0] : "#22c55e";
-
-      // Build stacked outer rings for multiplayer (one ring per team)
-      let ringsHtml = "";
-      if (teamColors && teamColors.length > 1) {
-        // Show stacked rings for multiple teams
-        const ringSize = 4;
-        teamColors.forEach((color, i) => {
-          const offset = i * ringSize;
-          ringsHtml += `<div class="absolute inset-0 rounded-full" style="border: 3px solid ${color}; margin: -${offset}px;"></div>`;
-        });
-      }
-
-      elementRef.current.innerHTML = `
-        <div class="relative w-16 h-16 rounded-full shadow-lg overflow-visible cursor-pointer transform -translate-y-1 hover:scale-110 transition-transform">
-          ${ringsHtml}
-          <div class="w-full h-full rounded-full border-4 overflow-hidden" style="border-color: ${primaryTeamColor};">
-            <img src="${photoUrl}" class="w-full h-full object-cover" alt="completed" />
-          </div>
-        </div>
-      `;
-    } else {
-      elementRef.current.innerHTML = `
-        <div class="w-14 h-14 bg-gray-400 rounded-full border-4 border-white shadow-lg flex items-center justify-center cursor-pointer transform -translate-y-1 hover:scale-110 transition-transform">
-          <span class="text-white text-2xl font-bold">?</span>
-        </div>
-      `;
-    }
-  }, [isCompleted, photoUrl, teamColors]);
+    elementRef.current.innerHTML = getMarkerContent(isCompleted, photoUrl, teamColors, order);
+  }, [isCompleted, photoUrl, teamColors, order]);
 
   return null;
-}
+});

--- a/src/components/POIModal.tsx
+++ b/src/components/POIModal.tsx
@@ -48,9 +48,9 @@ export function POIModal({ clue, onClose, onPhotoCapture }: POIModalProps) {
           </svg>
         </button>
 
-        {/* Clue */}
+        {/* Photo challenge */}
         <div className="mb-8 mt-4">
-          <h2 className="text-lg font-semibold text-gray-900 mb-2">Your Clue</h2>
+          <h2 className="text-lg font-semibold text-gray-900 mb-2">Photo Challenge</h2>
           <p className="text-gray-600 text-lg leading-relaxed">{clue}</p>
         </div>
 


### PR DESCRIPTION
## Summary
- Display POI order numbers on uncompleted pins instead of "?"
- Change "Your Clue" to "Photo Challenge" in POIModal
- Add lucide-react dependency
- Remove map attribution button
- Fix pin disappearing on modal close with memoization and duplicate marker guard

## Test plan
- [ ] Open /solo page
- [ ] Verify pins show order numbers (1, 2, 3...)
- [ ] Tap a pin and verify modal says "Photo Challenge"
- [ ] Close modal and verify pin doesn't disappear
- [ ] Verify no 'i' attribution button on map

🤖 Generated with [Claude Code](https://claude.com/claude-code)